### PR TITLE
feat: adds function to retrieve all results that match a query

### DIFF
--- a/src/aind_codeocean_api/__init__.py
+++ b/src/aind_codeocean_api/__init__.py
@@ -1,2 +1,2 @@
 """Python wrapper of CodeOcean's REST API"""
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -115,7 +115,7 @@ class CodeOceanClient:
         query: Optional[str] = None,
     ) -> requests.models.Response:
         """
-        Utility method to return all of the search results that match a query
+        Utility method to return all the search results that match a query
         Parameters
         ----------
         sort_order : Optional[str]

--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -148,15 +148,13 @@ class CodeOceanClient:
             if val is not None:
                 query_params[param] = val
 
-        start_index = 0
-        has_more_results = True
         requests_session = requests.Session()
-        start_index = 0
-        limit = self._MAX_SEARCH_BATCH_REQUEST
         all_results = []
         with requests.Session() as requests_session:
             has_more = True
             status_code = 200
+            start_index = 0
+            limit = self._MAX_SEARCH_BATCH_REQUEST
             while has_more and status_code == 200:
                 query_params["start"] = start_index
                 query_params["limit"] = limit

--- a/tests/test_codeocean_requests.py
+++ b/tests/test_codeocean_requests.py
@@ -1,6 +1,6 @@
 """Tests CodeOcean API python interface"""
-import unittest
 import json
+import unittest
 from typing import Any, Callable, List
 from unittest import mock
 
@@ -268,39 +268,48 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
         mocked_response1 = requests.Response()
         mocked_response1.status_code = 200
         mocked_response1._content = json.dumps(
-            {'has_more': True,
-             "results": [{"id": "abc123", "type": "dataset"},
-                         {"id": "def456", "type": "result"}]}
+            {
+                "has_more": True,
+                "results": [
+                    {"id": "abc123", "type": "dataset"},
+                    {"id": "def456", "type": "result"},
+                ],
+            }
         ).encode("utf-8")
 
         mocked_response2 = requests.Response()
         mocked_response2.status_code = 200
         mocked_response2._content = json.dumps(
-            {'has_more': False,
-             "results": [{"id": "ghi789", "type": "result"},
-                         {"id": "jkl101", "type": "result"}]}
+            {
+                "has_more": False,
+                "results": [
+                    {"id": "ghi789", "type": "result"},
+                    {"id": "jkl101", "type": "result"},
+                ],
+            }
         ).encode("utf-8")
 
         mock_api_get.side_effect = [mocked_response1, mocked_response2]
         response = self.co_client.search_all_data_assets()
 
-        expected_response = (
-            {"results": [{"id": "abc123", "type": "dataset"},
-                         {"id": "def456", "type": "result"},
-                         {"id": "ghi789", "type": "result"},
-                         {"id": "jkl101", "type": "result"}
-                         ]}
-        )
+        expected_response = {
+            "results": [
+                {"id": "abc123", "type": "dataset"},
+                {"id": "def456", "type": "result"},
+                {"id": "ghi789", "type": "result"},
+                {"id": "jkl101", "type": "result"},
+            ]
+        }
 
         actual_response = response.json()
 
         bad_response = requests.Response()
         bad_response.status_code = 500
         bad_response._content = json.dumps(
-            {'message': "Internal Server Error"}
+            {"message": "Internal Server Error"}
         ).encode("utf-8")
         mock_api_get.side_effect = [bad_response]
-        expected_bad_response = {'message': "Internal Server Error"}
+        expected_bad_response = {"message": "Internal Server Error"}
         response_bad = self.co_client.search_all_data_assets(archived=False)
         actual_bad_response = response_bad.json()
 
@@ -706,6 +715,7 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
 
         def mock_success_response() -> Callable[..., MockResponse]:
             """Mock a successful response"""
+
             def request_post_response(json: dict) -> MockResponse:
                 """Mock a post response"""
                 return MockResponse(status_code=204, content=None)
@@ -743,6 +753,7 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
 
         def mock_success_response() -> Callable[..., MockResponse]:
             """Mock a success response"""
+
             def request_post_response(json: dict) -> MockResponse:
                 """Mock a post response"""
                 return MockResponse(status_code=204, content=None)

--- a/tests/test_codeocean_requests.py
+++ b/tests/test_codeocean_requests.py
@@ -1,7 +1,10 @@
 """Tests CodeOcean API python interface"""
 import unittest
+import json
 from typing import Any, Callable, List
 from unittest import mock
+
+import requests
 
 from aind_codeocean_api.codeocean import CodeOceanClient
 
@@ -255,6 +258,56 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
 
         self.assertEqual(response.content, expected_response)
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch("requests.Session.get")
+    def test_search_all_data_assets(
+        self, mock_api_get: unittest.mock.MagicMock
+    ) -> None:
+        """Tests search_all_data_assets method."""
+
+        mocked_response1 = requests.Response()
+        mocked_response1.status_code = 200
+        mocked_response1._content = json.dumps(
+            {'has_more': True,
+             "results": [{"id": "abc123", "type": "dataset"},
+                         {"id": "def456", "type": "result"}]}
+        ).encode("utf-8")
+
+        mocked_response2 = requests.Response()
+        mocked_response2.status_code = 200
+        mocked_response2._content = json.dumps(
+            {'has_more': False,
+             "results": [{"id": "ghi789", "type": "result"},
+                         {"id": "jkl101", "type": "result"}]}
+        ).encode("utf-8")
+
+        mock_api_get.side_effect = [mocked_response1, mocked_response2]
+        response = self.co_client.search_all_data_assets()
+
+        expected_response = (
+            {"results": [{"id": "abc123", "type": "dataset"},
+                         {"id": "def456", "type": "result"},
+                         {"id": "ghi789", "type": "result"},
+                         {"id": "jkl101", "type": "result"}
+                         ]}
+        )
+
+        actual_response = response.json()
+
+        bad_response = requests.Response()
+        bad_response.status_code = 500
+        bad_response._content = json.dumps(
+            {'message': "Internal Server Error"}
+        ).encode("utf-8")
+        mock_api_get.side_effect = [bad_response]
+        expected_bad_response = {'message': "Internal Server Error"}
+        response_bad = self.co_client.search_all_data_assets(archived=False)
+        actual_bad_response = response_bad.json()
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(expected_response, actual_response)
+        self.assertEqual(500, response_bad.status_code)
+        self.assertEqual(expected_bad_response, actual_bad_response)
 
     @mock.patch("requests.put")
     def test_update_data_asset(


### PR DESCRIPTION
Closes #14 

 - Keeps connection alive to make multiple requests in a single session
 - Sets the max number of items returned in a single request to 1000 (not sure if code ocean has this)
 - Bundles the results into a requests.Response object to be aligned with the other methods.