### PR TITLE
Feat 22 capsule version

### DIFF
--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -347,6 +347,7 @@ class CodeOceanClient:
         self,
         capsule_id: str,
         data_assets: List[Dict],
+        version: Optional[str] = None,
         parameters: Optional[List] = None,
     ) -> requests.models.Response:
         """
@@ -361,6 +362,8 @@ class CodeOceanClient:
             List of dictionaries containing the following keys: 'id' which
             refers to the data asset id in Code Ocean and 'mount' which
             refers to the data asset mount folder.
+        version : Optional[str]
+            Capsule version to be run. Defaults to None.
         parameters : List
             Parameters given to the capsule. Default None which means
             the capsule runs with no parameters.
@@ -382,6 +385,8 @@ class CodeOceanClient:
 
         if parameters:
             data["parameters"] = parameters
+        if version:
+            data["version"] = version
 
         response = requests.post(
             url=self.computation_url, json=data, auth=(self.token, "")

--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -347,7 +347,7 @@ class CodeOceanClient:
         self,
         capsule_id: str,
         data_assets: List[Dict],
-        version: Optional[str] = None,
+        version: Optional[int] = None,
         parameters: Optional[List] = None,
     ) -> requests.models.Response:
         """
@@ -362,7 +362,7 @@ class CodeOceanClient:
             List of dictionaries containing the following keys: 'id' which
             refers to the data asset id in Code Ocean and 'mount' which
             refers to the data asset mount folder.
-        version : Optional[str]
+        version : Optional[int]
             Capsule version to be run. Defaults to None.
         parameters : List
             Parameters given to the capsule. Default None which means

--- a/tests/test_codeocean_requests.py
+++ b/tests/test_codeocean_requests.py
@@ -409,7 +409,7 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
             capsule_id=example_capsule_id, data_assets=[], parameters=["FOO"]
         )
         response2 = self.co_client.run_capsule(
-            capsule_id=example_capsule_id, data_assets=[], version="1"
+            capsule_id=example_capsule_id, data_assets=[], version=1
         )
         expected_response = {
             "created": 1646943238,

--- a/tests/test_codeocean_requests.py
+++ b/tests/test_codeocean_requests.py
@@ -408,6 +408,9 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
         response = self.co_client.run_capsule(
             capsule_id=example_capsule_id, data_assets=[], parameters=["FOO"]
         )
+        response2 = self.co_client.run_capsule(
+            capsule_id=example_capsule_id, data_assets=[], version="1"
+        )
         expected_response = {
             "created": 1646943238,
             "has_results": False,
@@ -418,6 +421,8 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
         }
         self.assertEqual(expected_response, response.content)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected_response, response2.content)
+        self.assertEqual(response2.status_code, 200)
 
     @mock.patch("requests.get")
     def test_get_capsule(self, mock_api_get: unittest.mock.MagicMock) -> None:


### PR DESCRIPTION
Closes #22 

- Adds option to specify a version number for Release capsules
- Only major versions are allowed under Code Ocean's current api.