### PR TITLE
Feat 25 configs class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dynamic = ["version"]
 
 dependencies = [
     'requests',
-    'aind-data-access-api[secrets]'
+    'pydantic<2.0',
+    'boto3'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'requests'
+    'requests',
+    'aind-data-access-api[secrets]'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional
 
 import requests
 
+from aind_codeocean_api.credentials import CodeOceanCredentials
+
 
 class CodeOceanClient:
     """Client that will connect to Code Ocean"""
@@ -69,18 +71,47 @@ class CodeOceanClient:
         self.token = token
         self.api_version = api_version
         self.logger = logging.getLogger("aind-codeocean-api")
-        self.asset_url = (
+
+    @property
+    def asset_url(self):
+        """Asset url property."""
+        return (
             f"{self.domain}/api/v{self.api_version}/"
             f"{self._URLStrings.DATA_ASSETS.value}"
         )
-        self.capsule_url = (
+
+    @property
+    def capsule_url(self):
+        """Capsule url property."""
+        return (
             f"{self.domain}/api/v{self.api_version}/"
             f"{self._URLStrings.CAPSULES.value}"
         )
-        self.computation_url = (
+
+    @property
+    def computation_url(self):
+        """Computation url property."""
+        return (
             f"{self.domain}/api/v{self.api_version}/"
             f"{self._URLStrings.COMPUTATIONS.value}"
         )
+
+    @classmethod
+    def from_credentials(
+        cls, credentials: CodeOceanCredentials, api_version: int = 1
+    ):
+        """
+        Create client using credentials object.
+        Parameters
+        ----------
+        credentials : CodeOceanCredentials
+        api_version :
+          Code Ocean API version
+
+        """
+        domain = credentials.domain
+        token = credentials.token.get_secret_value()
+        return cls(domain=domain, token=token, api_version=api_version)
 
     def get_data_asset(self, data_asset_id: str) -> requests.models.Response:
         """

--- a/src/aind_codeocean_api/codeocean.py
+++ b/src/aind_codeocean_api/codeocean.py
@@ -67,7 +67,7 @@ class CodeOceanClient:
         api_version : int
             Code Ocean API version
         """
-        self.domain = domain
+        self.domain = domain.strip("/")
         self.token = token
         self.api_version = api_version
         self.logger = logging.getLogger("aind-codeocean-api")

--- a/src/aind_codeocean_api/credentials.py
+++ b/src/aind_codeocean_api/credentials.py
@@ -2,90 +2,186 @@
 import json
 import os
 from pathlib import Path
+from typing import Any, Dict, Optional
 
-CREDENTIALS_FILENAME = "credentials.json"
-CREDENTIALS_DIR = ".codeocean"
-DEFAULT_ENV_VAR = "CODEOCEAN_CREDENTIALS_PATH"
-DEFAULT_HOME_PATH = Path.home() / CREDENTIALS_DIR / CREDENTIALS_FILENAME
+from aind_data_access_api.secrets import get_secret
+from pydantic import BaseSettings, Field, SecretStr, validator
+from pydantic.env_settings import (
+    EnvSettingsSource,
+    InitSettingsSource,
+    SecretsSettingsSource,
+)
 
 
-class CodeOceanCredentials:
-    """Class to hold CodeOcean Credentials"""
+class CodeOceanCredentials(BaseSettings):
 
-    @staticmethod
-    def _load_json(path: str) -> json:
-        """
-        Loads credentials from a path
-        Parameters
-        ----------
-        path : str
+    aws_secrets_name: Optional[str] = Field(
+        default=None,
+        repr=False,
+        description="Optionally pull credentials from aws secrets manager.",
+    )
+    config_file: Optional[Path] = Field(
+        default=None,
+        repr=False,
+        description="Optionally pull credentials from local config file.",
+    )
+    domain: str = Field(
+        ...,
+        title="Code Ocean Domain",
+        description=(
+            "Domain for Code Ocean platform "
+            "(e.g., https://acmecorp.codeocean.com)"
+        ),
+        env_prefix="codeocean_",
+    )
+    token: SecretStr = Field(
+        ...,
+        title="Code Ocean API Token",
+        description="API token for Code Ocean platform",
+        env_prefix="codeocean_",
+    )
 
-        Returns
-        -------
-        json
-        """
-        assert os.path.exists(path), f"credentials file {path} does not exist"
-        if os.path.exists(path):
-            with open(path, "r") as f:
-                return json.load(f)
+    @classmethod
+    def default_config_file_path(cls):
+        return cls.Config.secrets_dir
 
-    def __init__(self):
-        """Initializes credentials."""
+    @validator("domain", pre=True)
+    def _strip_trailing_slash(cls, input_domain):
+        return input_domain.strip("/")
 
-        if os.environ.get(DEFAULT_ENV_VAR):
-            filepath = os.environ.get(DEFAULT_ENV_VAR)
-        else:
-            filepath = str(DEFAULT_HOME_PATH)
+    class Config:
+        """This class will add custom sourcing from aws."""
 
-        self.credentials = self._load_json(filepath)
+        # Prefix to append to env vars
+        env_prefix = "CODEOCEAN_"
 
-    @staticmethod
-    def create_credentials(
-        api_domain: str, access_token: str, file_location: str
-    ) -> None:
-        """
-        Takes in credential information from
-        user input and create a credentials.json file.
+        # Default location of the config file
+        secrets_dir = (
+            Path(os.path.expanduser("~")) / ".codeocean" / "credentials.json"
+        )
 
-        Parameters
-        ---------------
-        api_domain : string
-            API domain
-        access_token : string
-            API Access Token
-        file_location : str
-            File path where credentials.json file is written to
+        @staticmethod
+        def settings_from_config_file(config_file: Optional[Path]):
+            """
+            Curried function that returns a function to retrieve creds from
+            a file.
+            Parameters
+            ----------
+            config_file : Optional[Path]
+              Location of json file to retrieve the creds from.
 
-        Returns
-        ---------------
-        None
-            Writes to file
-        """
+            Returns
+            -------
+            A function that retrieves the credentials.
 
-        with open(file_location, "w+") as output:
+            """
+
+            def set_settings(_: BaseSettings) -> Dict[str, Any]:
+                """
+                A simple settings source that loads from a file
+                """
+                if config_file is None or not os.path.isfile(config_file):
+                    return {}
+                else:
+                    with open(config_file, "r") as f:
+                        contents = json.load(f)
+                    return contents
+
+            return set_settings
+
+        @staticmethod
+        def settings_from_aws(secrets_name: Optional[str]):
+            """
+            Curried function that returns a function to retrieve creds from aws
+            Parameters
+            ----------
+            secrets_name : Optional[str]
+              Name of the credentials we wish to retrieve
+            Returns
+            -------
+            A function that retrieves the credentials.
+            """
+
+            def set_settings(_: BaseSettings) -> Dict[str, Any]:
+                """
+                A simple settings source that loads from aws secrets manager
+                """
+                credentials_from_aws = get_secret(secrets_name)
+                return credentials_from_aws
+
+            return set_settings
+
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: InitSettingsSource,
+            env_settings: EnvSettingsSource,
+            file_secret_settings: SecretsSettingsSource,
+        ):
+            """Class method to return custom sources."""
+
+            # Check if aws_secrets_name is defined during instantiation
+            aws_secrets_name = init_settings.init_kwargs.get(
+                "aws_secrets_name"
+            )
+            # Check if config_file is defined during instantiation
+            config_file = init_settings.init_kwargs.get("config_file")
+            domain = init_settings.init_kwargs.get("domain")
+            token = init_settings.init_kwargs.get("token")
+            env_domain = os.getenv((cls.env_prefix + "domain").upper())
+            env_token = os.getenv((cls.env_prefix + "token").upper())
+
+            # If user inputs aws_secrets_name, ignore all other settings
+            if aws_secrets_name:
+                return cls.settings_from_aws(secrets_name=aws_secrets_name)
+            # If a user defines a config_file, ignore all other settings
+            elif config_file is not None:
+                return cls.settings_from_config_file(config_file)
+            # If a user attempts to construct object using init args and env
+            # vars, ignore looking for a default config file
+            elif (domain or env_domain) and (token or env_token):
+                return (
+                    init_settings,
+                    env_settings,
+                )
+            # Otherwise, attempt to pull creds from default creds file location
+            else:
+                return (
+                    cls.settings_from_config_file(
+                        file_secret_settings.secrets_dir
+                    ),
+                )
+
+    def save_credentials_to_file(self):
+        """Saves domain and token to the file defined in config_file field or
+        the default_config_file_path if config_file is None."""
+
+        # Use default path if config_file is None
+        output_path = (
+            self.default_config_file_path()
+            if self.config_file is None
+            else self.config_file
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w+") as output:
             json.dump(
-                {"domain": api_domain, "token": access_token}, output, indent=4
+                {
+                    "domain": self.domain,
+                    "token": self.token.get_secret_value(),
+                },
+                output,
+                indent=4,
             )
 
 
 if __name__ == "__main__":
     # Prompt user
     user_input_file_path = input(
-        f"Save to (Leave blank to default to {DEFAULT_HOME_PATH}): "
+        f"Save to (Leave blank to save to default location"
+        f" {CodeOceanCredentials.default_config_file_path()}): "
     )
     domain = input("Domain (e.g. https://acmecorp.codeocean.com): ")
-    token = input("Access Token: ")
-
-    # Use default file path if none entered
-    if user_input_file_path:
-        file_path = user_input_file_path
-    elif os.environ.get(DEFAULT_ENV_VAR):
-        file_path = os.environ.get(DEFAULT_ENV_VAR)
-    else:
-        file_path = str(DEFAULT_HOME_PATH)
-
-    Path(file_path).parent.mkdir(exist_ok=True, parents=True)
-
-    CodeOceanCredentials.create_credentials(
-        api_domain=domain, access_token=token, file_location=file_path
-    )
+    token = input("API Token: ")
+    CodeOceanCredentials(
+        domain=domain, token=token, config_file=user_input_file_path
+    ).save_credentials_to_file()

--- a/src/aind_codeocean_api/credentials.py
+++ b/src/aind_codeocean_api/credentials.py
@@ -4,13 +4,29 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from aind_data_access_api.secrets import get_secret
+import boto3
 from pydantic import BaseSettings, Field, SecretStr, validator
 from pydantic.env_settings import (
     EnvSettingsSource,
     InitSettingsSource,
     SecretsSettingsSource,
 )
+
+
+# Small helper function to get an aws secret
+def get_secret(secret_name: str) -> dict:
+    """
+    Retrieves a secret from AWS Secrets Manager.
+
+    param secret_name: The name of the secret to retrieve.
+    """
+    # Create a Secrets Manager client
+    client = boto3.client("secretsmanager")
+    try:
+        response = client.get_secret_value(SecretId=secret_name)
+    finally:
+        client.close()
+    return json.loads(response["SecretString"])
 
 
 class CodeOceanCredentials(BaseSettings):

--- a/tests/test_codeocean_requests.py
+++ b/tests/test_codeocean_requests.py
@@ -8,6 +8,7 @@ from unittest.mock import call
 import requests
 
 from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_codeocean_api.credentials import CodeOceanCredentials
 
 
 class MockResponse:
@@ -157,6 +158,14 @@ class TestCodeOceanDataAssetRequests(unittest.TestCase):
         )
         self.assertEqual(response.content, expected_request_response)
         self.assertEqual(response.status_code, 200)
+
+    def test_create_from_credentials(self):
+        """Tests that the client can be constructed from a
+        CodeOceanCredentials object"""
+        creds = CodeOceanCredentials(domain="some_domain", token="some_token")
+        client = CodeOceanClient.from_credentials(credentials=creds)
+        self.assertEqual("some_domain", client.domain)
+        self.assertEqual("some_token", client.token)
 
     @mock.patch("requests.get")
     def test_get_data_asset(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,9 +3,10 @@ import json
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, call, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch, Mock
+from botocore.exceptions import ClientError
 
-from aind_codeocean_api.credentials import CodeOceanCredentials
+from aind_codeocean_api.credentials import CodeOceanCredentials, get_secret
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 FAKE_CREDENTIALS_PATH = TEST_DIR / "resources" / "fake_credentials.json"
@@ -176,6 +177,57 @@ class TestCredentials(unittest.TestCase):
             ],
             any_order=True,
         )
+
+    @patch("boto3.client")
+    def test_get_secret_success(self, mock_boto3_client):
+        """Tests that secret is retrieved as expected"""
+        # Mock the Secrets Manager client and response
+        mock_client = Mock()
+        mock_boto3_client.return_value = mock_client
+        mock_secret_string = (
+            '{"username": "admin",'
+            ' "password": "secret_password",'
+            ' "host": "some host",'
+            ' "database": "some database"}'
+        )
+        mock_response = {"SecretString": mock_secret_string}
+        mock_client.get_secret_value.return_value = mock_response
+
+        # Call the get_secret method with a mock secret name
+        secret_name = "my_secret"
+        secret_value = get_secret(secret_name)
+
+        # Assert that the client was called with the correct arguments
+        mock_boto3_client.assert_called_with("secretsmanager")
+        mock_client.get_secret_value.assert_called_with(
+            SecretId=secret_name)
+
+        # Assert that the secret value returned matches the expected value
+        expected_value = {
+            "username": "admin",
+            "password": "secret_password",
+            "host": "some host",
+            "database": "some database",
+        }
+        self.assertEqual(secret_value, expected_value)
+
+    @patch("boto3.client")
+    def test_get_secret_permission_denied(self, mock_boto3_client):
+        """Tests  secret retrieval fails with incorrect aws permissions"""
+        mock_boto3_client.return_value.get_secret_value.side_effect = (
+            ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "HTTPStatusCode": 403,
+                    }
+                },
+                "get_secret_value",
+            )
+        )
+        # Assert that ClientError is raised
+        with self.assertRaises(ClientError):
+            get_secret("my_secret")
 
 
 if __name__ == "__main__":

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,8 +1,9 @@
 """Tests credentials loader."""
+import json
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from aind_codeocean_api.credentials import CodeOceanCredentials
 
@@ -13,6 +14,21 @@ FAKE_PATH_USER_INPUT = TEST_DIR / "resources"
 
 class TestCredentials(unittest.TestCase):
     """Tests credentials class methods."""
+
+    EXAMPLE_ENV_VARS = {
+        "CODEOCEAN_DOMAIN": "http://acmecorp-env.com",
+        "CODEOCEAN_TOKEN": "123-abc-e",
+    }
+    EXAMPLE_AWS_SECRETS = {
+        "domain": "http://acmecorp-aws.com",
+        "token": "123-abc-a",
+    }
+    EXAMPLE_CONFIG_FILE = json.dumps(
+        {
+            "domain": "http://acmecorp-cfg.com",
+            "token": "123-abc-c",
+        }
+    )
 
     def test_basic_init(self):
         """Tests that the credentials can be instantiated with class
@@ -25,17 +41,9 @@ class TestCredentials(unittest.TestCase):
         self.assertEqual("http://acmecorp.com", creds.domain)
         self.assertEqual("123-abc", creds.token.get_secret_value())
 
-    @patch.dict(
-        os.environ,
-        (
-            {
-                "CODEOCEAN_DOMAIN": "http://acmecorp-env.com",
-                "CODEOCEAN_TOKEN": "123-abc-e",
-            }
-        ),
-        clear=True,
-    )
+    @patch.dict(os.environ, EXAMPLE_ENV_VARS, clear=True)
     def test_env_vars(self):
+        """Tests setting credentials from environment variables."""
         creds_from_env = CodeOceanCredentials()
         creds_combo_1 = CodeOceanCredentials(domain="http://acmecorp.com/")
         creds_combo_2 = CodeOceanCredentials(token="123-abc")
@@ -51,6 +59,123 @@ class TestCredentials(unittest.TestCase):
         self.assertEqual("123-abc", creds_combo_2.token.get_secret_value())
         self.assertEqual("http://acmecorp.com", creds_combo_3.domain)
         self.assertEqual("123-abc", creds_combo_3.token.get_secret_value())
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VARS, clear=True)
+    @patch("aind_codeocean_api.credentials.get_secret")
+    def test_from_aws(self, mock_get_secret: MagicMock):
+        """Tests pulling credentials from aws secrets manager."""
+
+        mock_get_secret.return_value = self.EXAMPLE_AWS_SECRETS
+        creds_from_aws = CodeOceanCredentials(aws_secrets_name="mocked_secret")
+        creds_from_aws2 = CodeOceanCredentials(
+            aws_secrets_name="mocked_secret", domain="a_url", token="tkn"
+        )
+        self.assertEqual("http://acmecorp-aws.com", creds_from_aws.domain)
+        self.assertEqual("123-abc-a", creds_from_aws.token.get_secret_value())
+        self.assertEqual("http://acmecorp-aws.com", creds_from_aws2.domain)
+        self.assertEqual("123-abc-a", creds_from_aws2.token.get_secret_value())
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VARS, clear=True)
+    @patch("aind_codeocean_api.credentials.get_secret")
+    def test_from_aws_error(self, mock_get_secret: MagicMock):
+        """Tests situation where an error is raised when attempting to set
+        credentials through aws_secrets_name."""
+
+        def mock_error(_):
+            """Mock an error."""
+            raise Exception("An error occurred connecting to aws.")
+
+        mock_get_secret.side_effect = mock_error
+
+        with self.assertRaises(Exception) as e:
+            CodeOceanCredentials(
+                aws_secrets_name="mocked_secret", domain="a_url", token="tkn"
+            )
+        self.assertEqual(
+            "Exception('An error occurred connecting to aws.')",
+            repr(e.exception),
+        )
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VARS, clear=True)
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data=EXAMPLE_CONFIG_FILE
+    )
+    @patch("os.path.isfile")
+    def test_from_file(self, mock_is_file: MagicMock, mock_file: MagicMock):
+        """Tests setting creds from file."""
+        mock_is_file.return_value = True
+        creds_from_file = CodeOceanCredentials(
+            config_file="mocked_file", domain="some_url"
+        )
+        # Assert the domain set in the file overrides the domain set in init
+        self.assertEqual("http://acmecorp-cfg.com", creds_from_file.domain)
+        self.assertEqual("123-abc-c", creds_from_file.token.get_secret_value())
+        mock_file.assert_called_once_with("mocked_file", "r")
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VARS, clear=True)
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data=EXAMPLE_CONFIG_FILE
+    )
+    @patch("os.path.isfile")
+    def test_from_file_error(
+        self, mock_is_file: MagicMock, mock_file: MagicMock
+    ):
+        """Tests case where an error is raised when attempting to access a
+        file"""
+
+        # Mock an issue where the file doesn't exist
+        mock_is_file.return_value = False
+        # Assert if config_file is in init args, and an error occurs, then
+        # just raise an Exception instead of attempting to fallback
+        with self.assertRaises(Exception) as e:
+            CodeOceanCredentials(config_file="mocked_file", domain="some_url")
+        err_message = (
+            "ValidationError(model='CodeOceanCredentials', "
+            "errors=["
+            "{'loc': ('domain',), 'msg': 'field required', 'type':"
+            " 'value_error.missing'}, "
+            "{'loc': ('token',), 'msg': 'field required', 'type':"
+            " 'value_error.missing'}])"
+        )
+        self.assertEqual(err_message, repr(e.exception))
+
+        mock_file.assert_not_called()
+
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data=EXAMPLE_CONFIG_FILE
+    )
+    @patch("os.path.isfile")
+    def test_fallback_to_default_file(
+        self, mock_is_file: MagicMock, mock_file: MagicMock
+    ):
+        """Tests that final fallback is to search for the default file."""
+        mock_is_file.return_value = True
+        creds_from_file = CodeOceanCredentials()
+        # Assert the domain set in the file overrides the domain set in init
+        self.assertEqual("http://acmecorp-cfg.com", creds_from_file.domain)
+        self.assertEqual("123-abc-c", creds_from_file.token.get_secret_value())
+        default_path = creds_from_file.default_config_file_path()
+        mock_file.assert_called_once_with(default_path, "r")
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_to_file(self, mock_file: MagicMock):
+        """Test save to file method."""
+        creds = CodeOceanCredentials(domain="domain", token="token")
+        creds2 = CodeOceanCredentials(domain="domain", token="token")
+        creds2.config_file = Path("some_path")
+        default_path = creds.default_config_file_path()
+        creds.save_credentials_to_file()
+        creds.save_credentials_to_file(output_path=Path("a_path"))
+        creds2.save_credentials_to_file()
+
+        mock_file.assert_has_calls(
+            [
+                call(default_path, "w+"),
+                call(Path("a_path"), "w+"),
+                call(Path("some_path"), "w+"),
+            ],
+            any_order=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #25 
Closes #43 
- Uses pydantic BaseSettings to define and manage credentials
- Allows credentials to be defined either through the class constructor, environment variables, a config file, or to be pulled from aws secrets manager
- As final fallback, will attempt to locate credentials in `Path(USERS_HOME/.codeocean/credentials.json)`
- Adds pre-validator that strips trailing slash from domain name
- Adds method in client to construct from_credentials object. Leaves legacy way in place too.
- Redefines a few dependent client attributes as properties
- Renames `CodeOceanCredentials.create_credentials` method to `CodeOceanCredentials.save_credentials_to_file`. Also changes it from a static method to an instance method. This should be the only backwards incompatible change. The command line prompt interface is still the same if a user decides to create the credentials file through the command line though.
- Adds `aind-data-access-api[secrets]` dependency. Before it was just requests.